### PR TITLE
Providing a SecDispatcher to build a DefaultSettingsDecrypter

### DIFF
--- a/src/main/java/capsule/UserSettings.java
+++ b/src/main/java/capsule/UserSettings.java
@@ -186,7 +186,7 @@ final class UserSettings {
             }
         };
 
-        final DefaultSettingsDecrypter decrypter = new DefaultSettingsDecrypter();
+        final DefaultSettingsDecrypter decrypter = new DefaultSettingsDecrypter(secDispatcher);
 
         try {
             java.lang.reflect.Field field = decrypter.getClass().getDeclaredField("securityDispatcher");


### PR DESCRIPTION
When building for a Debian packaging, I met an issue as an argument was needed for the constructor of org.apache.maven.settings.crypto.DefaultSettingsDecrypter coming from maven 3.6.3. Providing secDispatcher, introduced just above in your code, fixes the build issue.
Yet this needs a review to ensure it is correct.