### PR TITLE
Providing the needed List<String> as first argument of dm.resolveDependencies

### DIFF
--- a/src/test/java/MavenCapsuleTest.java
+++ b/src/test/java/MavenCapsuleTest.java
@@ -175,7 +175,7 @@ public class MavenCapsuleTest {
         deps.put(dep, as);
 
         when(dm.resolveDependency(dep, type)).thenReturn(as);
-        when(dm.resolveDependencies(anyList(), eq(type))).thenAnswer(new Answer<List<Path>>() {
+        when(dm.resolveDependencies(anyListOf(String.class), eq(type))).thenAnswer(new Answer<List<Path>>() {
             @Override
             public List<Path> answer(InvocationOnMock invocation) throws Throwable {
                 List<String> coords = (List<String>) invocation.getArguments()[0];


### PR DESCRIPTION
When building with the version 2.23.0 of mockito, I had to provide a List<String> instead of a List<Object> as the first argument of dm.resolveDependencies. This code fixes the issue.